### PR TITLE
[hack] fix hacky scripts and server logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,9 @@ project(':org.alloytools.alloy.grpc') {
         implementation 'org.sat4j:org.sat4j.maxsat:2.3.1'
         implementation 'org.sat4j:org.sat4j.pb:2.3.1'
 
-        // Logging
-        implementation 'org.slf4j:slf4j-api:2.0.9'
-        runtimeOnly 'org.slf4j:slf4j-simple:2.0.9'
+        // Logging - using SLF4J 1.x for compatibility with Alloy dependencies
+        implementation 'org.slf4j:slf4j-api:1.7.36'
+        implementation 'org.slf4j:slf4j-simple:1.7.36'
 
         // JSON processing
         implementation 'com.google.code.gson:gson:2.10.1'

--- a/org.alloytools.alloy.grpc/hacks/start-server.sh
+++ b/org.alloytools.alloy.grpc/hacks/start-server.sh
@@ -8,7 +8,7 @@ set -e
 
 # Get the directory of this script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PROJECT_ROOT="$(dirname $(dirname "$SCRIPT_DIR"))"
 
 # Default port
 PORT=${1:-50051}

--- a/org.alloytools.alloy.grpc/hacks/test-server.sh
+++ b/org.alloytools.alloy.grpc/hacks/test-server.sh
@@ -3,8 +3,6 @@
 # Alloy gRPC Server Test Script
 # Tests all major endpoints to verify the server is working correctly
 
-set -e
-
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -100,7 +98,7 @@ echo -e "${BLUE}6. ❌ Error Handling Test:${NC}"
   "output_format": "OUTPUT_FORMAT_JSON",
   "solver_type": "SOLVER_TYPE_SAT4J"
 }' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve
-if [ $? -eq 0 ]; then
+if [ ! $? -eq 0 ]; then
     echo -e "${GREEN}✅ Error handling test passed${NC}"
 else
     echo -e "${RED}❌ Error handling test failed${NC}"

--- a/org.alloytools.alloy.grpc/src/main/resources/simplelogger.properties
+++ b/org.alloytools.alloy.grpc/src/main/resources/simplelogger.properties
@@ -1,0 +1,32 @@
+# SLF4J Simple Logger Configuration for SLF4J 1.x
+# This file configures the SLF4J Simple Logger implementation
+
+# Default log level for all loggers
+# Valid levels: trace, debug, info, warn, error, off
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+# Show date and time in log output
+org.slf4j.simpleLogger.showDateTime=true
+
+# Date and time format
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss
+
+# Show thread name in log output
+org.slf4j.simpleLogger.showThreadName=true
+
+# Show logger name in log output
+org.slf4j.simpleLogger.showLogName=true
+
+# Show short logger name (only the class name, not the full package)
+org.slf4j.simpleLogger.showShortLogName=false
+
+# Log level for specific loggers - enable debug for gRPC service
+org.slf4j.simpleLogger.log.org.alloytools.alloy.grpc=debug
+org.slf4j.simpleLogger.log.io.grpc=info
+org.slf4j.simpleLogger.log.root=info
+
+# Log to stderr instead of stdout
+org.slf4j.simpleLogger.logFile=System.err
+
+# Enable level in brackets
+org.slf4j.simpleLogger.levelInBrackets=true


### PR DESCRIPTION
$ ./org.alloytools.alloy.grpc/hacks/start-server.sh 🚀 Starting Alloy gRPC Server...
📍 Project root: /home/mohit/hub/org.alloytools.alloy 🔌 Port: 50051

🔨 Building project...
✅ Build successful!

🌟 Starting Alloy gRPC Server on port 50051...
   Press Ctrl+C to stop the server
   Server will be available at: localhost:50051

> Task :org.alloytools.alloy.grpc:extractIncludeProto UP-TO-DATE
> Task :org.alloytools.alloy.grpc:extractProto UP-TO-DATE
> Task :org.alloytools.alloy.grpc:generateProto UP-TO-DATE
> Task :org.alloytools.alloy.grpc:compileJava UP-TO-DATE
> Task :org.alloytools.alloy.grpc:processResources UP-TO-DATE
> Task :org.alloytools.alloy.grpc:classes UP-TO-DATE

> Task :org.alloytools.alloy.grpc:run
2025-07-13 23:09:00 [main] [INFO] org.alloytools.alloy.grpc.api.AlloyGrpcServer - Alloy gRPC server started on port 50051 2025-07-13 23:09:00 [main] [INFO] org.alloytools.alloy.grpc.api.AlloyGrpcServer - Alloy gRPC server is running on port 50051

$ ./org.alloytools.alloy.grpc/hacks/test-server.sh 🎉 All tests completed successfully!
📊 Test Summary:
  ✅ Health Check
  ✅ Ping Endpoint
  ✅ Service Discovery
  ✅ Simple Model Solving
  ✅ Complex Model Solving
  ✅ Error Handling

🚀 Your Alloy gRPC Server is working perfectly!