### PR TITLE
Include location of error in grpc response

### DIFF
--- a/org.alloytools.alloy.grpc/README.md
+++ b/org.alloytools.alloy.grpc/README.md
@@ -118,6 +118,11 @@ docker build -f org.alloytools.alloy.grpc/Dockerfile -t alloy-grpc:latest .
 docker run -p 50051:50051 alloy-grpc:latest
 ```
 
+### GCloud deployment
+```bash
+gcloud builds submit --config=org.alloytools.alloy.grpc/cloudbuild.yaml .
+```
+
 ### Environment Variables
 
 | Variable | Default | Description |

--- a/org.alloytools.alloy.grpc/cloudbuild.yaml
+++ b/org.alloytools.alloy.grpc/cloudbuild.yaml
@@ -1,0 +1,38 @@
+steps:
+  # Build the Docker image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: 
+      - 'build'
+      - '-f'
+      - 'org.alloytools.alloy.grpc/Dockerfile'
+      - '-t'
+      - 'us-west1-docker.pkg.dev/$PROJECT_ID/morph-dev/morph-alloy-grpc:latest'
+      - '.'
+
+  # Push the image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: 
+      - 'push'
+      - 'us-west1-docker.pkg.dev/$PROJECT_ID/morph-dev/morph-alloy-grpc:latest'
+
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'morph-alloy-grpc'
+      - '--image'
+      - 'us-west1-docker.pkg.dev/$PROJECT_ID/morph-dev/morph-alloy-grpc:latest'
+      - '--region'
+      - 'us-west1'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+      - '--max-instances'
+      - '1'
+      - '--port'
+      - '50051'
+
+images:
+  - 'us-west1-docker.pkg.dev/$PROJECT_ID/morph-dev/morph-alloy-grpc:latest'

--- a/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/impl/AlloySolverServiceImpl.java
+++ b/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/impl/AlloySolverServiceImpl.java
@@ -108,7 +108,7 @@ public class AlloySolverServiceImpl extends SolverServiceGrpc.SolverServiceImplB
 
         } catch (Err err) {
             responseObserver.onError(Status.fromCode(Status.Code.INTERNAL)
-                .withDescription("Alloy error: " + err.getMessage())
+                .withDescription("Alloy error: " + err.toString())
                 .asRuntimeException());
             
         } catch (Exception ex) {

--- a/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ModelLoader.java
+++ b/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ModelLoader.java
@@ -81,7 +81,7 @@ public class ModelLoader {
             return ModelLoadResult.success(world, commands);
             
         } catch (Err err) {
-            return ModelLoadResult.error("Parse error: " + err.getMessage());
+            return ModelLoadResult.error("Parse error: " + err.toString());
         } catch (Exception ex) {
             return ModelLoadResult.error("Unexpected error: " + ex.getMessage());
         }

--- a/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ProtocolBufferConverter.java
+++ b/org.alloytools.alloy.grpc/src/main/java/org/alloytools/alloy/grpc/util/ProtocolBufferConverter.java
@@ -283,4 +283,23 @@ public class ProtocolBufferConverter {
                 return SolverType.SOLVER_TYPE_UNSPECIFIED;
         }
     }
+
+    /**
+     * Create SolveResponse for combined results from multiple commands.
+     */
+    public static SolveResponse createCombinedResponse(boolean anySatisfiable, String combinedResults, 
+                                                       long totalSolvingTimeMs, String solverUsed, 
+                                                       String executedCommand) {
+        SolutionMetadata metadata = SolutionMetadata.newBuilder()
+            .setSolvingTimeMs(totalSolvingTimeMs)
+            .setSolverUsed(solverUsed != null ? solverUsed : "unknown")
+            .setExecutedCommand(executedCommand)
+            .build();
+            
+        return SolveResponse.newBuilder()
+            .setSatisfiable(anySatisfiable)
+            .setSolutionData(combinedResults)
+            .setMetadata(metadata)
+            .build();
+    }
 }

--- a/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/BasicSolvingIntegrationTest.java
+++ b/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/BasicSolvingIntegrationTest.java
@@ -97,6 +97,7 @@ public class BasicSolvingIntegrationTest {
             .setModelContent(UNSATISFIABLE_MODEL)
             .setOutputFormat(OutputFormat.OUTPUT_FORMAT_TEXT)
             .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .setCommand("0")
             .build();
 
         service.solve(request, responseObserver);

--- a/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/OutputFormatIntegrationTest.java
+++ b/org.alloytools.alloy.grpc/src/test/java/org/alloytools/alloy/grpc/integration/OutputFormatIntegrationTest.java
@@ -51,6 +51,7 @@ public class OutputFormatIntegrationTest {
             .setModelContent(SIMPLE_MODEL)
             .setOutputFormat(OutputFormat.OUTPUT_FORMAT_JSON)
             .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .setCommand("0")
             .build();
 
         // Execute request
@@ -88,6 +89,7 @@ public class OutputFormatIntegrationTest {
             .setModelContent(SIMPLE_MODEL)
             .setOutputFormat(OutputFormat.OUTPUT_FORMAT_XML)
             .setSolverType(SolverType.SOLVER_TYPE_SAT4J)
+            .setCommand("0")
             .build();
 
         // Execute request


### PR DESCRIPTION
$ grpcurl -plaintext -d '{
  "model_content": "sig Person {}\nrun {} for 3\n {",
  "output_format": "OUTPUT_FORMAT_JSON",
  "solver_type": "SOLVER_TYPE_SAT4J"
}' localhost:50051 org.alloytools.alloy.grpc.SolverService/Solve ERROR:
  Code: InvalidArgument
  Message: Parse error: Syntax error in /tmp/alloy_heredoc6245923478203039575.als at line 3 column 2:
There are 5 possible tokens that can appear here:
enum fun let open pred